### PR TITLE
:pencil2: [Fix] 판매자의 다른 거래글 가져오는 쿼리 및 자잘한 점 수정

### DIFF
--- a/src/main/java/com/karrotclone/api/SalesPostApiController.java
+++ b/src/main/java/com/karrotclone/api/SalesPostApiController.java
@@ -63,11 +63,11 @@ public class SalesPostApiController {
      * @return 거래글 상세글 표시에 필요한 데이터 DTO
      * @since 2023-02-24
      * @createdBy 노민준
-     * @lastModified 2023-02-24
+     * @lastModified 2023-02-26
      */
     @ApiOperation(value="거래글 상세페이지 정보 가져오기", notes="id에 해당하는 거래글의 상세페이지 정보를 가져옵니다.")
     @GetMapping("/api/post/{id}")
-    public ResponseEntity<ResponseDto> getSalesPostDetail(@RequestParam("id") Long id){
+    public ResponseEntity<ResponseDto> getSalesPostDetail(@PathVariable("id") Long id){
 
         ResponseDto responseDto = new ResponseDto();
 
@@ -81,7 +81,7 @@ public class SalesPostApiController {
 
             //현재 거래글을 올린 판매자의 다른 최신 거래글 DTO 리스트, 최대 4개
             List<SalesPostSimpleDto> postsFromSeller =
-                    salesPostRepository.findDistinctTop4ByMemberAndIdNotOrderByIdDesc(findPost.getMember(), id)
+                    salesPostRepository.findTop4ListBySeller(findPost.getMember(), id)
                             .stream().map(SalesPostSimpleDto::new).collect(Collectors.toList());
 
             //상세페이지 DTO안에 거래글 리스트 추가

--- a/src/main/java/com/karrotclone/domain/SalesPost.java
+++ b/src/main/java/com/karrotclone/domain/SalesPost.java
@@ -36,7 +36,6 @@ public class SalesPost {
     private Category category; //카테고리
     private LocalDateTime createDateTime; //작성일자
     private PreferPlace preferPlace; //거래 희망 장소(선택)
-    private boolean isShare; //나눔여부
     private boolean isNegoAvailable; //가격제안 가능 여부
     @Enumerated(value = EnumType.STRING)
     private OpenRange openRange; //보여줄 동네 범위
@@ -52,7 +51,6 @@ public class SalesPost {
         this.title = form.getTitle();
         this.category = form.getCategory();
         this.price = form.getPrice();
-        this.isShare = form.isShare();
         this.isNegoAvailable = form.isNegoAvailable();
         this.content = form.getContent();
         this.preferPlace = form.getPreferPlace();

--- a/src/main/java/com/karrotclone/domain/enums/Category.java
+++ b/src/main/java/com/karrotclone/domain/enums/Category.java
@@ -8,25 +8,25 @@ import java.awt.print.Book;
  * @createdBy 노민준
  */
 public enum Category {
-    Digital, //디지털기기
-    Appliance, //생활가전
-    Interior, //가구, 인테리어
-    HomeAndKitchen, //생활, 주방
-    KidProduct, //유아제품
-    KidBook, //유아도서
-    WomenClothes, //여성의류
-    WomenAccessory, //여성잡화
-    MenFashion, //남성패션
-    Beauty, //뷰티, 미용
-    Sports, //스포츠
-    Hobby, //취미, 게임, 음반
-    Car, //중고차
-    Book, //도서
-    Ticket, //티켓, 교환권
-    Food, //가공식품
-    Pet, //반려동물 용품
-    Plant, //식물
-    Etc, //기타
+    DIGITAL, //디지털기기
+    APPLIANCE, //생활가전
+    INTERIOR, //가구, 인테리어
+    HOME_KITCHEN, //생활, 주방
+    KID_PRODUCT, //유아제품
+    KID_BOOK, //유아도서
+    WOMEN_CLOTHES, //여성의류
+    WOMEN_ACCESSORY, //여성잡화
+    MEN_FASHION, //남성패션
+    BEAUTY, //뷰티, 미용
+    SPORTS, //스포츠
+    HOBBY, //취미, 게임, 음반
+    CAR, //중고차
+    BOOK, //도서
+    TICKET, //티켓, 교환권
+    FOOD, //가공식품
+    PET, //반려동물 용품
+    PLANT, //식물
+    ETC, //기타
 
     //private String value;
 

--- a/src/main/java/com/karrotclone/domain/enums/OpenRange.java
+++ b/src/main/java/com/karrotclone/domain/enums/OpenRange.java
@@ -4,5 +4,5 @@ package com.karrotclone.domain.enums;
  * 글 공개범위를 나타내는 enum입니다.
  */
 public enum OpenRange {
-    VeryClose, Close, Middle, Far
+    VERY_CLOSE, CLOSE, MIDDLE, FAR
 }

--- a/src/main/java/com/karrotclone/dto/CreateSalesPostForm.java
+++ b/src/main/java/com/karrotclone/dto/CreateSalesPostForm.java
@@ -23,7 +23,6 @@ public class CreateSalesPostForm {
     private String title; //제목
     private Category category; //카테고리
     private long price; //가격
-    private boolean isShare; //나눔여부
     private boolean isNegoAvailable; //가격제안 가능여부
     private String content; //글 내용
     private PreferPlace preferPlace; //거래 희망 장소(선택)

--- a/src/main/java/com/karrotclone/dto/SalesPostDetailDto.java
+++ b/src/main/java/com/karrotclone/dto/SalesPostDetailDto.java
@@ -30,7 +30,6 @@ public class SalesPostDetailDto {
     private Category category; //카테고리
     private LocalDateTime createDateTime; //작성시간
     private SalesState salesState; //거래상태
-    private boolean isShare; //나눔여부
     private boolean isNegoAvailable; //가격제안 가능여부
     private int views; //조회수
     private int favoriteUserCount; //관심수
@@ -46,7 +45,6 @@ public class SalesPostDetailDto {
         this.category = post.getCategory();
         this.createDateTime = post.getCreateDateTime();
         this.salesState = post.getSalesState();
-        this.isShare = post.isShare();
         this.isNegoAvailable = post.isNegoAvailable();
         this.views = post.getViews();
         this.favoriteUserCount = post.getFavoriteUserCount();

--- a/src/main/java/com/karrotclone/repository/SalesPostQueryRepository.java
+++ b/src/main/java/com/karrotclone/repository/SalesPostQueryRepository.java
@@ -1,0 +1,22 @@
+package com.karrotclone.repository;
+
+import com.karrotclone.domain.Member;
+import com.karrotclone.domain.SalesPost;
+
+import java.util.List;
+
+/**
+ * 거래글과 관련된 복잡한 쿼리를 사용하기 위한 인터페이스입니다.
+ */
+public interface SalesPostQueryRepository {
+
+    /**
+     * DB에서 판매자가 최근에 등록한 거래글 리스트를 찾아서 반환합니다. (최대4개)
+     * 인자로 들어온 id와 같은 거래글이거나 거래상태가 완료일 경우는 제외합니다.
+     * @param member 판매자
+     * @param id 중복되면 안되는 id
+     * @return 찾아낸 거래글 리스트
+     * @since 2023-02-26
+     */
+    List<SalesPost> findTop4ListBySeller(Member member, Long id);
+}

--- a/src/main/java/com/karrotclone/repository/SalesPostQueryRepositoryImpl.java
+++ b/src/main/java/com/karrotclone/repository/SalesPostQueryRepositoryImpl.java
@@ -1,0 +1,42 @@
+package com.karrotclone.repository;
+
+import com.karrotclone.domain.Member;
+import com.karrotclone.domain.SalesPost;
+import com.karrotclone.domain.enums.SalesState;
+
+import javax.persistence.EntityManager;
+import javax.persistence.EntityManagerFactory;
+import java.util.List;
+
+/**
+ * 거래글과 관련된 복잡한 쿼리를 구현한 클래스입니다.
+ * @since 2023-02-26
+ * @createdBy 노민준
+ */
+public class SalesPostQueryRepositoryImpl implements SalesPostQueryRepository{
+
+    private final EntityManager em;
+
+    public SalesPostQueryRepositoryImpl(EntityManager em){ this.em = em;}
+
+    /**
+     * DB에서 판매자가 최근에 등록한 거래글 리스트를 찾아서 반환합니다. (최대4개)
+     * 인자로 들어온 id와 같은 거래글이거나 거래상태가 완료일 경우는 제외합니다.
+     * 결과는 ID 내림차순 정렬
+     * @param member 판매자
+     * @param id 중복되면 안되는 id
+     * @return 찾아낸 거래글 리스트
+     * @since 2023-02-26
+     */
+    @Override
+    public List<SalesPost> findTop4ListBySeller(Member member, Long id) {
+        return em.createQuery("SELECT s " +
+                        "FROM SalesPost s " +
+                        "WHERE s.id != :id AND s.salesState != :salesState " +
+                        "ORDER BY s.id DESC", SalesPost.class)
+                .setParameter("id", id)
+                .setParameter("salesState", SalesState.COMPLETE)
+                .setMaxResults(4)
+                .getResultList();
+    }
+}

--- a/src/main/java/com/karrotclone/repository/SalesPostRepository.java
+++ b/src/main/java/com/karrotclone/repository/SalesPostRepository.java
@@ -14,19 +14,7 @@ import java.util.List;
  * @since 2023-02-23
  * @createdBy 노민준
  */
-public interface SalesPostRepository extends JpaRepository<SalesPost, Long> {
+public interface SalesPostRepository extends JpaRepository<SalesPost, Long>, SalesPostQueryRepository {
 
-    /**
-     * 판매자가 올린 거래글 최신순으로 최대 4개 가져옵니다.
-     * 이때 주어진 id와 일치하는 거래글은 가져오지않습니다.
-     * 각 판매글의 멤버를 페치조인해서 가져옵니다.
-     * @param member 판매자
-     * @param id 겹치지않게 할 거래글 id값
-     * @return 가져온 거래글 List
-     * @since 2023-02-24
-     * @createdBy 노민준
-     * @lastModified 2023-02-24
-     */
-    List<SalesPost> findDistinctTop4ByMemberAndIdNotOrderByIdDesc(Member member, Long id);
 
 }


### PR DESCRIPTION
- 판매자의 다른 거래글 가져오는 쿼리에서 거래글 상태가 거래완료일 경우 제외하는 로직 추가
- 상수이름을 UpperCase로 수정
- 거래글 상세페이지 가져오는 URI 수정, 기존에 id를 RequestParam으로 받은걸 PathVariable로 알맞게 수정
- 거래글의 나눔여부 필드 삭제