### PR TITLE
:sparkles: [New] 거래글 관련 이미지 업로드 및 이미지 url 반환 로직 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.1.RELEASE'
+	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	//롬복

--- a/src/main/java/com/karrotclone/config/AwsConfig.java
+++ b/src/main/java/com/karrotclone/config/AwsConfig.java
@@ -1,0 +1,34 @@
+package com.karrotclone.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * AWS를 사용하기 위해서 빈 객체를 등록하는 클래스입니다.
+ */
+@Configuration
+public class AwsConfig {
+
+    @Value("${cloud.aws.iam.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.iam.secret-key}")
+    private String secretKey;
+
+    private String region = "ap-northeast-2";
+
+    @Bean
+    public AmazonS3Client amazonS3Client(){
+        BasicAWSCredentials basicAWSCredentials = new BasicAWSCredentials(accessKey, secretKey);
+        return (AmazonS3Client) AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(basicAWSCredentials))
+                .build();
+    }
+
+}

--- a/src/main/java/com/karrotclone/controller/HomeController.java
+++ b/src/main/java/com/karrotclone/controller/HomeController.java
@@ -1,0 +1,14 @@
+package com.karrotclone.controller;
+
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class HomeController {
+
+    @GetMapping("/") //이미지 업로드 테스트용 화면
+    public String test(){
+        return "test";
+    }
+}

--- a/src/main/java/com/karrotclone/domain/SalesPost.java
+++ b/src/main/java/com/karrotclone/domain/SalesPost.java
@@ -8,6 +8,8 @@ import lombok.*;
 
 import javax.persistence.*;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 판매글을 나타내는 엔티티 객체입니다.
@@ -29,8 +31,12 @@ public class SalesPost {
     @JoinColumn(name = "member_id")
     private Member member; //작성자
 
-    private long price; //가격
+    @ElementCollection(fetch = FetchType.LAZY)
+    @Column(name = "image_url")
+    private List<String> imageUrls = new ArrayList<>(); //상품 이미지 url
+
     private String title; //글 제목
+    private long price; //가격
     private String content; //글 내용
     @Enumerated(value = EnumType.STRING)
     private Category category; //카테고리

--- a/src/main/java/com/karrotclone/dto/CreateSalesPostForm.java
+++ b/src/main/java/com/karrotclone/dto/CreateSalesPostForm.java
@@ -7,12 +7,16 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 판매글 생성 시 필요한 데이터 폼입니다.
  * @since 2023-02-23
  * @createdBy 노민준
- * @lastModified 2023-02-23
+ * @lastModified 2023-02-28
  */
 @Data
 @Builder
@@ -20,6 +24,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class CreateSalesPostForm {
 
+    private List<MultipartFile> images = new ArrayList<>(); //이미지 파일들
     private String title; //제목
     private Category category; //카테고리
     private long price; //가격

--- a/src/main/java/com/karrotclone/dto/ImageTestDto.java
+++ b/src/main/java/com/karrotclone/dto/ImageTestDto.java
@@ -1,0 +1,12 @@
+package com.karrotclone.dto;
+
+import lombok.Data;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Data
+public class ImageTestDto {
+    private List<MultipartFile> images;
+    private String name;
+}

--- a/src/main/java/com/karrotclone/dto/SalesPostDetailDto.java
+++ b/src/main/java/com/karrotclone/dto/SalesPostDetailDto.java
@@ -10,12 +10,14 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
  * 거래글 화면 상세페이지에서 필요한 데이터를 나타내는 DTO입니다.
  * @since 2023-02-24
  * @createdBy 노민준
+ * @lastModified 2023-02-28
  */
 @Data
 @Builder
@@ -23,6 +25,7 @@ import java.util.List;
 @NoArgsConstructor
 public class SalesPostDetailDto {
 
+    private List<String> imageUrls = new ArrayList<>(); //이미지 링크 리스트
     private String nickName; //판매자 닉네임
     private String title; //글제목
     private String content; //글내용
@@ -38,6 +41,7 @@ public class SalesPostDetailDto {
     private List<SalesPostSimpleDto> postsFromSeller; //판매자가 등록한 다른 판매글
 
     public SalesPostDetailDto(SalesPost post){
+        this.imageUrls = post.getImageUrls();
         this.nickName = post.getMember().getNickName();
         this.title = post.getTitle();
         this.content = post.getContent();

--- a/src/main/java/com/karrotclone/dto/SalesPostSimpleDto.java
+++ b/src/main/java/com/karrotclone/dto/SalesPostSimpleDto.java
@@ -14,6 +14,7 @@ import java.time.LocalDateTime;
  * 거래글 목록 화면에서 각 상품의 정보를 나타내는 DTO입니다.
  * @since 2023-02-24
  * @createdBy 노민준
+ * @lastModified 2023-02-28
  */
 @Data
 @Builder
@@ -21,6 +22,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 public class SalesPostSimpleDto {
 
+    private String imageUrl; //상품 이미지 url리스트
     private long id; //거래글 id
     private String title; //글제목
     private long price; //가격
@@ -31,6 +33,9 @@ public class SalesPostSimpleDto {
     private int chatCount; //채팅수
 
     public SalesPostSimpleDto(SalesPost post){
+        if(post.getImageUrls().size() > 0){
+            this.imageUrl = post.getImageUrls().get(0);
+        }
         this.id = post.getId();
         this.title = post.getTitle();
         this.price = post.getPrice();

--- a/src/main/java/com/karrotclone/repository/SalesPostQueryRepositoryImpl.java
+++ b/src/main/java/com/karrotclone/repository/SalesPostQueryRepositoryImpl.java
@@ -20,18 +20,20 @@ public class SalesPostQueryRepositoryImpl implements SalesPostQueryRepository{
     public SalesPostQueryRepositoryImpl(EntityManager em){ this.em = em;}
 
     /**
-     * DB에서 판매자가 최근에 등록한 거래글 리스트를 찾아서 반환합니다. (최대4개)
-     * 인자로 들어온 id와 같은 거래글이거나 거래상태가 완료일 경우는 제외합니다.
-     * 결과는 ID 내림차순 정렬
+     * DB에서 판매자가 최근에 등록한 거래글 리스트를 찾아서 반환합니다. (최대4개) <br>
+     * 이미지 url을 페치조인합니다. <br>
+     * 인자로 들어온 id와 같은 거래글이거나 거래상태가 완료일 경우는 제외합니다. <br>
+     * 결과는 ID 내림차순 정렬 <br>
      * @param member 판매자
      * @param id 중복되면 안되는 id
      * @return 찾아낸 거래글 리스트
-     * @since 2023-02-26
+     * @since 2023-02-28
      */
     @Override
     public List<SalesPost> findTop4ListBySeller(Member member, Long id) {
         return em.createQuery("SELECT s " +
                         "FROM SalesPost s " +
+                        "JOIN FETCH s.imageUrls " + //이미지 url 가져올 때 N+1 방지
                         "WHERE s.id != :id AND s.salesState != :salesState " +
                         "ORDER BY s.id DESC", SalesPost.class)
                 .setParameter("id", id)

--- a/src/main/java/com/karrotclone/repository/SalesPostRepository.java
+++ b/src/main/java/com/karrotclone/repository/SalesPostRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 /**
  * 거래글용 DAO입니다
@@ -15,6 +16,5 @@ import java.util.List;
  * @createdBy 노민준
  */
 public interface SalesPostRepository extends JpaRepository<SalesPost, Long>, SalesPostQueryRepository {
-
 
 }

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,6 +1,10 @@
 spring:
   profiles: dev
 
+  servlet:
+    multipart:
+      max-file-size: 10MB #업로드 파일 사이즈 제한
+      max-request-size: 10MB #업로드 파일 사이즈 제한
 
   devtools:
     livereload:
@@ -37,3 +41,15 @@ jasypt:
       prefix: ENC(
       suffix: )
   password: djifajdcznvkzc
+
+#AWS 설정
+cloud:
+  aws:
+    iam:
+      access-key: ENC(Hi+Pynput2jHrHT0BGmk1TvNijKIlsgBrKh9SWMdVcQ=)
+      secret-key: ENC(QrdVsRutSbWU90oHj3GybHkvTJF/W6d41L6Xvox1sS8eqmfLYE5WkpuIOsT+e9bqCwXHvrEY/Mw=)
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false
+

--- a/src/main/resources/application-temp.yml
+++ b/src/main/resources/application-temp.yml
@@ -1,6 +1,10 @@
 spring:
   profiles: temp
 
+  servlet:
+    multipart:
+      max-file-size: 10MB #업로드 파일 사이즈 제한
+      max-request-size: 10MB #업로드 파일 사이즈 제한
 
   devtools:
     livereload:
@@ -27,3 +31,14 @@ jasypt:
       prefix: ENC(
       suffix: )
   password: djifajdcznvkzc
+
+#AWS 설정
+cloud:
+  aws:
+    iam:
+      access-key: ENC(Hi+Pynput2jHrHT0BGmk1TvNijKIlsgBrKh9SWMdVcQ=)
+      secret-key: ENC(QrdVsRutSbWU90oHj3GybHkvTJF/W6d41L6Xvox1sS8eqmfLYE5WkpuIOsT+e9bqCwXHvrEY/Mw=)
+    region:
+      static: ap-northeast-2
+    stack:
+      auto: false

--- a/src/main/resources/templates/test.html
+++ b/src/main/resources/templates/test.html
@@ -1,0 +1,13 @@
+<!DOCTYPE HTML>
+<html xmlns:th="http://www.thymeleaf.org">
+<body>
+
+<div>
+    <form action="/imagetest" method="post" enctype="multipart/form-data">
+        <input type="file" multiple="multiple" name="images" accept="image/*">
+        <input name="name">
+        <button type="submit">제출</button>
+    </form>
+</div> <!-- /container -->
+</body>
+</html>


### PR DESCRIPTION
- 거래글 생성 시 contentType을 multipart/form-data으로 받을 수 있게 변경, 받은 이미지파일을 s3에 업로드 후 이미지의 url을 거래글 엔티티에 추가

- 거래글 상세페이지 정보 요청 시 반환할 dto에 이미지 url 추가